### PR TITLE
Retrieve all SQS message attributes

### DIFF
--- a/src/main/java/io/interact/sqsdw/SqsListenerImpl.java
+++ b/src/main/java/io/interact/sqsdw/SqsListenerImpl.java
@@ -30,6 +30,11 @@ public class SqsListenerImpl implements SqsListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqsListenerImpl.class);
 
+    /**
+     * SQS message receiver flag that indicates all message attributes should be returned
+     */
+    private static final String ATTR_ALL = "All";
+
     private final AtomicBoolean healthy = new AtomicBoolean(true);
     private final AmazonSQS sqs;
     private final String sqsListenQueueUrl;
@@ -69,7 +74,7 @@ public class SqsListenerImpl implements SqsListener {
                 while (!isInterrupted()) {
                     try {
                         ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(sqsListenQueueUrl)
-                                .withMessageAttributeNames(MessageHandler.ATTR_MESSAGE_TYPE);
+                                .withMessageAttributeNames(ATTR_ALL);
                         List<Message> messages = sqs.receiveMessage(receiveMessageRequest).getMessages();
                         for (int i = 0; i < messages.size(); i++) {
                             Message msg = messages.get(i);


### PR DESCRIPTION
The `SQSListenerImpl` class currently constructs a `ReceiveMessageRequest` instance with a call to the `withMessageAttributeNames` method with only the `MessageType` attribute.  The result is that only the `MessageType` attribute will be set on received messages.

This pull-request constructs the `ReceiveMessageRequest` instance with the `All` value given to the `withMessageAttributeNames` method.  This will cause all message attributes to be included:
http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/model/ReceiveMessageRequest.html#withMessageAttributeNames(java.lang.String...)
