### PR TITLE
update aws-java-sdk dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'com.amazonaws:aws-java-sdk:1.9.10'
+    compile 'com.amazonaws:aws-java-sdk-sqs:1.9.10'
     compile "io.dropwizard:dropwizard-core:${dropwizardVersion}"
     compile "io.dropwizard:dropwizard-logging:${dropwizardVersion}"
     compile "io.dropwizard:dropwizard-validation:${dropwizardVersion}"


### PR DESCRIPTION
This changes the dependency library as suggested in #7. There are newer versions of the java SDK available, but I kept the version at `1.9.10` so that it would be easier to test. (This change + #8 results in all tests still passing)
