### PR TITLE
Delete Message behaviour change 

### DIFF
--- a/src/main/java/io/interact/sqsdw/sqs/SqsListenerImpl.java
+++ b/src/main/java/io/interact/sqsdw/sqs/SqsListenerImpl.java
@@ -86,18 +86,19 @@ public class SqsListenerImpl implements SqsListener {
                                     if (handler.canHandle(msg)) {
                                         LOG.debug("Message accepted.");
                                         handler.handle(msg);
+                                        String messageRecieptHandle = msg.getReceiptHandle();
+                                        sqs.deleteMessage(new DeleteMessageRequest(sqsListenQueueUrl, messageRecieptHandle));
+                                        LOG.debug(String.format("Message %s of %s is processed and deleted from queue '%s'", i + 1,
+                                                messages.size(), sqsListenQueueUrl));
                                     } else {
                                         LOG.debug("Message refused.");
                                     }
                                 }
+
                             } catch (Exception e) {
                                 logProcessingError(msg, e);
                             }
 
-                            String messageRecieptHandle = msg.getReceiptHandle();
-                            sqs.deleteMessage(new DeleteMessageRequest(sqsListenQueueUrl, messageRecieptHandle));
-                            LOG.debug(String.format("Message %s of %s is processed and deleted from queue '%s'", i + 1,
-                                    messages.size(), sqsListenQueueUrl));
                         }
 
                         boolean recovered = healthy.compareAndSet(false, true);


### PR DESCRIPTION
Similar to issue #11 - the way messages are deleted doesn't work for my use case - I only want to remove a message once I know it's been processed properly. I haven't made this configurable, but happy to look at it.  